### PR TITLE
Fix PDF pages not using available height

### DIFF
--- a/src/styles/journal-improvements.scss
+++ b/src/styles/journal-improvements.scss
@@ -148,3 +148,12 @@
     top: 0 !important;
   }
 }
+
+.sheet.journal-entry .journal-entry-page.pdf {
+    height: 100%;
+}
+
+.journal-entry-page.pdf iframe {
+    min-height: unset;
+    flex-basis: unset;
+}


### PR DESCRIPTION
There is a large blank of empty space in PDFs vertically. This fixes it. Inspired on farling's commit.